### PR TITLE
Update requirements_dev.txt to fix djangorestframework-gis dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -114,7 +114,7 @@ djangorestframework==3.14.0
     #   django-oapif
     #   django-rest-knox
     #   djangorestframework-gis
-djangorestframework-gis @ git+https://github.com/openwisp/django-rest-framework-gis@4f244d5d8a7ad5b453fd04f64150818d15123e01
+djangorestframework-gis @ git+https://github.com/openwisp/django-rest-framework-gis@82d9f0aa2457bb695bce9514f4fb055ddaa6a688
     # via
     #   -r requirements.txt
     #   django-oapif


### PR DESCRIPTION
EDIT: I upgraded packages according to documentation like this and it fixed the build, so maybe not necessary to merge?

```
docker compose exec kablo pip-compile -U requirements.in
docker compose exec kablo pip install -r requirements.txt
```